### PR TITLE
Fix for jekyll menus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "minima", "~> 2.0"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+# gem "github-pages", group: :jekyll_plugins 
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "minima", "~> 2.0"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
-   gem "jekyll-menus"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,6 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.9.2)
       jekyll (~> 3.3)
-    jekyll-menus (0.6.0)
-      jekyll (~> 3.1)
     jekyll-sass-converter (1.5.1)
       sass (~> 3.4)
     jekyll-watch (1.5.1)


### PR DESCRIPTION
Hi,

This is a pull request from Forestry. I've made some changes to your dependencies. Removing the jekyll-menus gem fixes the import issue. 

Note: It doesn't look like you are but please only merge this pull request if you're certain that you're not using jekyll-menus at the moment. 

Best,
Sebastian

Forestry.io